### PR TITLE
Fix snapcraft.yaml (use go1.8)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,8 @@
         command: mdview
         plugs: [home,unity7]
   parts:
+    go:
+      source-tag: go1.8
     mdview:
-      build-packages: [golang]
       plugin: go
+      after: [go]


### PR DESCRIPTION
Hi,

This fixes the snapcraft build by using go1.8.

Thanks for creating a snap :)