### PR TITLE
Add the ability to open from file manager

### DIFF
--- a/snap/gui/mdview.desktop
+++ b/snap/gui/mdview.desktop
@@ -1,3 +1,4 @@
 [Desktop Entry]
 Name=Markdown View
 Exec=mdview
+MimeType=text/markdown


### PR DESCRIPTION
Voila!

![2018-10-30 14-11-18](https://user-images.githubusercontent.com/40228953/47711269-45b74a80-dc4e-11e8-9833-1c2ccd3397da.png)

Markdown opener isn't opener if it doesn't open from a file manager.
