### PR TITLE
Support reading an environment variable for the directory to write to

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Formats markdown and launches it in a browser.
 
 ### Arch Linux (and derivatives)
 
-Mdview is now available in the [AUR](https://aur.archlinux.org/packages/mdview/)  
+Markdown View is now available in the [AUR](https://aur.archlinux.org/packages/mdview/)
 If you have an AUR helper like `yay`, installing is as easy as:
 ```
 yay -S mdview
@@ -17,7 +17,9 @@ yay -S mdview
 ### Debian Package
 
 If you're running Debian or a derivative like Ubuntu or Pop!_OS,
-download the [deb package](https://github.com/mapitman/mdview/releases/download/1.4.0/mdview-1.4.0_amd64.deb).
+download the deb package for the release you'd like to install form the
+[Releases](https://github.com/mapitman/mdview/releases) page.
+Install with `dpkg -i`
 
 ```sh
 curl -O https://github.com/mapitman/mdview/releases/download/1.4.0/mdview-1.4.0_amd64.deb
@@ -31,6 +33,10 @@ sudo dpkg --remove mdview
 ```
 
 ### Snap Package
+
+_Update 2023-09-17_: I can't really recommend this method of installation
+as it is cumbersome. Also, the Snap build seems to be broken and I don't
+really know what to do to fix it!
 
 On Linux, you can install [mdview](https://snapcraft.io/mdview) from the snap store. This option is only viable if the files
 you want to view are in your home directory. If you need to view
@@ -65,6 +71,17 @@ Don't have Golang? [Get it now](https://golang.org/doc/install).
 
 ## Usage
 
+By default, `mdview` tries to use your operating system's temporary
+directory. To write HTML files to. If that doesn't work for you, you can
+set an environment variable that it will use instead. For example, on
+Ubuntu Linux, Firefox is packaged as a Snap and is unable to read from
+`/tmp`. I get around this by setting `MDVIEW_DIR` like so:
+
+```sh
+export MDVIEW_DIR=$HOME/snap/firefox/mdview
+```
+
+
 ```text
 Usage:
 mdview [options] <filename>
@@ -83,4 +100,4 @@ Formats markdown and launches it in a browser.
 ```
 
 If you do not supply an output file, mdview will write a file to your
-operating system's default temp directory.
+operating system's default temp directory or to the value of MDVIEW_DIR.

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	if inputFilename == "" || *helpPtr {
-		os.Stderr.WriteString("Usage:\nmdview [options] <filename>\nFormats markdown and launches it in a browser.\n")
+		os.Stderr.WriteString("Usage:\nmdview [options] <filename>\nFormats markdown and launches it in a browser.\nIf the environment variable MDVIEW_DIR is set, the temporary file will be written there.\n")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
@@ -78,6 +78,16 @@ func tempFileName(prefix, suffix string) string {
 }
 
 func getTempDir() string {
+	if os.Getenv("MDVIEW_DIR") != "" {
+		var tempDir = os.Getenv(("MDVIEW_DIR"))
+		if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+			err = os.Mkdir(tempDir, 0700)
+			check(err)
+		}
+
+		return tempDir
+	}
+
 	if os.Getenv("SNAP_USER_COMMON") != "" {
 		var tmpdir = os.Getenv("HOME") + "/mdview-temp"
 		if _, err := os.Stat(tmpdir); os.IsNotExist(err) {
@@ -86,6 +96,7 @@ func getTempDir() string {
 		}
 		return tmpdir
 	}
+
 	return os.TempDir()
 }
 

--- a/mdview.1.md
+++ b/mdview.1.md
@@ -12,7 +12,9 @@
 # DESCRIPTION
 
 Formats a markdown file as HTML, writes it to a temporary file and
-then launches that file in the default web browser.
+then launches that file in the default web browser. By default, it will
+use the operating system's default temporary directory unless the
+environment variable MDVIEW_DIR is set.
 
 ## Options
 


### PR DESCRIPTION
If an environment variable MDVIEW_DIR is present, HTML files will be written there instead of the default OS temporary directory.

One reason for this is that Firefox on Ubuntu is now distributed as a Snap and it can't read from /tmp.

Closes #12