### PR TITLE
Suppress stderr and stdout messages from browser

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ func main() {
 	_, err = fmt.Fprintf(f, template, actualStyle, title, html)
 	check(err)
 	f.Sync()
+	browser.Stderr = nil
+	browser.Stdout = nil
 	err = browser.OpenFile(outfilePath)
 	check(err)
 }


### PR DESCRIPTION
To keep the terminal uncluttered, this change will suppress messages written by the web browser to stdout and stderr

Fixes #14