### PR TITLE
Handle permission denied error a little better

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "env": {},
-            "args": ["README.md"]
+            "env": {"SNAP_USER_COMMON": "mark"},
+            "args": ["bad-perms.md"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "env": {"SNAP_USER_COMMON": "mark"},
-            "args": ["bad-perms.md"]
+            "env": {},
+            "args": ["README.md"]
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,7 +100,7 @@ func getTempDir() string {
 		return tempDir
 	}
 
-	if os.Getenv("SNAP_USER_COMMON") != "" {
+	if isSnap() {
 		var tmpdir = os.Getenv("HOME") + "/mdview-temp"
 		if _, err := os.Stat(tmpdir); os.IsNotExist(err) {
 			err = os.Mkdir(tmpdir, 0700)
@@ -113,7 +114,16 @@ func getTempDir() string {
 
 func check(e error) {
 	if e != nil {
-		panic(e)
+		if os.IsPermission(e) {
+			fmt.Println("There was a permission error accessing the file.")
+			if isSnap() {
+				fmt.Println("Since mdview was installed as a Snap, it can only access files in your HOME directory.")
+				fmt.Println("If you need to use it with files outside of your HOME directory, choose a different installation method.")
+				fmt.Println("https://github.com/mapitman/mdview?tab=readme-ov-file#installation\n")
+			}
+		}
+
+		log.Fatal(e)
 	}
 }
 
@@ -149,4 +159,8 @@ func getText(token markdown.Token) string {
 	}
 	return ""
 
+}
+
+func isSnap() bool {
+	return os.Getenv("SNAP_USER_COMMON") != ""
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,15 +18,11 @@ adopt-info: mdview
 parts:
   mdview:
     override-pull: |
-      craftctl default
-      craftctl set version=$(git describe --tags --abbrev=10)
+      craftctl pull
+      craftctl set VERSION=$(git describe  --tags | sed 's/-.*//')
     plugin: go
     source: .
     source-type: git
-    # build-packages:
-    #   - gcc
-    #   - gcc-multilib
-    #   - libblkid-dev
     build-snaps:
       - go
 architectures:


### PR DESCRIPTION
Print a friendlier message when permission is denied. If mdview was installed via Snap, print a little more info about the limitations of Snap packages.

Closes #32