### PR TITLE
Read markdown from standard input when the filename is -

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Requires Go (see `go.mod`/`mise.toml` for version) and, for packaging, `just`, `
 
 Everything happens in `main()` in `main.go`, in a straight-line pipeline:
 
-1. **Flag parsing** — `-o`, `-v/-version`, `-h/-help`, `-b/-bare`. First positional arg is the input markdown file.
+1. **Flag parsing** — `-o`, `-v/-version`, `-h/-help`, `-b/-bare`. First positional arg is the input markdown file; a single `-` reads the markdown from stdin instead, in which case `baseDir` for image resolution is the working directory rather than the input file's directory.
 2. **Image inlining** (`processMarkdownImages` → `processHTMLImages`/markdown image regex + `imageToDataURI`) — rewrites relative image references (both `![]()`  markdown syntax and raw `<img src=...>` HTML) into base64 `data:` URIs *before* markdown parsing, so the output HTML is fully self-contained/offline-viewable. This includes path-traversal guards (caps `..` traversal depth) and a 10MB per-image size cap.
 3. **Markdown parsing** via Goldmark, configured with:
    - `extension.GFM` (tables, task lists, strikethrough, etc.)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ A lightweight command-line tool that converts markdown files to styled HTML and 
 
 ## Usage
 
+Pass a filename, or a single dash to read markdown from standard input:
+
+```sh
+mdview notes.md
+cat notes.md | mdview -
+age -d -i ~/.config/age/key.txt notes.md.age | mdview -
+```
+
+Reading from standard input avoids writing the markdown to disk first,
+which is useful when the content is decrypted or generated on the fly.
+Relative image paths are then resolved against the current working
+directory.
+
 By default, `mdview` writes the generated HTML to a temporary directory.
 It tries these in order:
 - A path defined in the `MDVIEW_DIR` environment variable

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -59,16 +60,28 @@ func main() {
 	}
 
 	if inputFilename == "" || *helpPtr {
-		os.Stderr.WriteString("Usage:\nmdview [options] <filename>\nFormats markdown and launches it in a browser.\nIf the environment variable MDVIEW_DIR is set, the temporary file will be written there.\n")
+		os.Stderr.WriteString("Usage:\nmdview [options] <filename>\nFormats markdown and launches it in a browser.\nUse - as the filename to read markdown from standard input.\nIf the environment variable MDVIEW_DIR is set, the temporary file will be written there.\n")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	dat, err := os.ReadFile(inputFilename)
-	check(err)
+	// A filename of - means read the markdown from standard input. Relative image
+	// paths are then resolved against the working directory, as there is no input
+	// file to anchor them to.
+	var dat []byte
+	var err error
+	baseDir := "."
+
+	if inputFilename == "-" {
+		dat, err = io.ReadAll(os.Stdin)
+		check(err)
+	} else {
+		dat, err = os.ReadFile(inputFilename)
+		check(err)
+		baseDir = filepath.Dir(inputFilename)
+	}
 
 	// Convert relative image links to data URIs in the markdown source
-	baseDir := filepath.Dir(inputFilename)
 	processedMarkdown := processMarkdownImages(string(dat), baseDir)
 	processedBytes := []byte(processedMarkdown)
 

--- a/mdview.1.md
+++ b/mdview.1.md
@@ -7,6 +7,7 @@
 # SYNOPSIS
 
 **mdview** _filename_  
+**mdview** **-**  
 **mdview** \[**-h**|**--help**|**-v**|**--version**]
 
 # DESCRIPTION
@@ -15,6 +16,10 @@ Formats a markdown file as HTML, writes it to a temporary file and
 then launches that file in the default web browser. By default, it will
 use the operating system's default temporary directory unless the
 environment variable MDVIEW_DIR is set.
+
+If _filename_ is a single dash (**-**), the markdown is read from
+standard input. Relative image paths are then resolved against the
+current working directory.
 
 ## Options
 


### PR DESCRIPTION
## What

`mdview -` now reads the markdown from standard input instead of from a file.

## Why

Piping markdown in avoids writing it to disk first. That matters when the content is decrypted or generated on the fly, where a temporary plaintext file is undesirable:

```sh
age -d -i ~/.config/age/key.txt notes.md.age | mdview -
```

Previously the only option was to decrypt to a temp file, view it, then delete it, which leaves plaintext on disk for the lifetime of the command.

## How

When the first positional argument is `-`, `main()` reads with `io.ReadAll(os.Stdin)`. Otherwise the existing `os.ReadFile` path is unchanged.

Relative image paths resolve against the working directory in the stdin case, since there is no input file to anchor them to. The rest of the pipeline (image inlining, Goldmark parsing, title extraction, mermaid embedding, templating) is untouched.

## Verification

Checked manually, as the repo has no test suite:

- stdin and file input produce byte-identical HTML for the same content
- H1 title extraction works through the pipe
- empty stdin renders an empty document rather than crashing
- `-b`/`-bare` works via stdin
- missing-file errors are unchanged
- end to end: `age -d ... | mdview -` renders the decrypted content

## Also updated

`mdview.1.md`, `README.md`, and `CLAUDE.md` to document the new form.

No CHANGELOG entry: entries there are per-release with dates and PR numbers, so this belongs to the next release rather than the branch.

Two pre-existing issues were left alone, both in code this branch does not touch: a `go vet` redundant-newline warning in the Snap hint, and some `gofmt` comment-alignment drift.